### PR TITLE
Removing obsolete parameters and adding the correct one under ahc.

### DIFF
--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -85,8 +85,7 @@ gatling {
       }
     }
     ahc {
-      #allowPoolingConnections = true             # Allow pooling HTTP connections (keep-alive header automatically added)
-      #allowPoolingSslConnections = true          # Allow pooling HTTPS connections (keep-alive header automatically added)
+      #keepAlive = true                           # Allow pooling of connections. allowPoolingConnections & allowPoolingSslConnections are now obsolete
       #compressionEnforced = false                # Enforce gzip/deflate when Accept-Encoding header is not defined
       #connectTimeout = 60000                     # Timeout when establishing a connection
       #pooledConnectionIdleTimeout = 60000        # Timeout when a connection stays unused in the pool


### PR DESCRIPTION
Justification-
    [ERROR] i.g.c.c.GatlingConfiguration$ - Your gatling.conf file is outdated, some properties have been renamed or removed.
    Please update (check gatling.conf in Gatling bundle, or gatling-defaults.conf in gatling-core jar).
    Enabled obsolete properties:
    'gatling.http.ahc.allowPoolingSslConnections' was removed, dropped.
    'gatling.http.ahc.allowPoolingConnections' was renamed into gatling.http.ahc.keepAlive.