### PR TITLE
Include org.apache.maven.plugins in plugin section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <testSourceDirectory>src/test/scala</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven-jar-plugin.version}</version>
       </plugin>


### PR DESCRIPTION
In IntelliJ it wouldn't recognise the scala-maven-plugin.version value; i added the additional line to match the entry at https://blogs.apache.org/maven/entry/apache-maven-jar-plugin-version3 and it resolved the problem for me.