### PR TITLE
add missing groupid for maven-jar-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <testSourceDirectory>src/test/scala</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven-jar-plugin.version}</version>
       </plugin>


### PR DESCRIPTION
Missing group id of maven-jar-plugin caused of warning from IDE